### PR TITLE
[TF-2349] - i18n

### DIFF
--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -13,6 +13,7 @@ require 'grape-swagger/doc_methods/move_params'
 require 'grape-swagger/doc_methods/headers'
 require 'grape-swagger/doc_methods/build_model_definition'
 require 'grape-swagger/doc_methods/version'
+require 'grape-swagger/doc_methods/translate'
 
 module GrapeSwagger
   module DocMethods

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -98,6 +98,7 @@ module GrapeSwagger
         add_version: true,
         hide_documentation_path: true,
         format: :json,
+        i18n_scope: :api,
         authorizations: nil,
         security_definitions: nil,
         security: nil,
@@ -116,7 +117,7 @@ module GrapeSwagger
     end
 
     def tags_from(paths, options)
-      tags = GrapeSwagger::DocMethods::TagNameDescription.build(paths)
+      tags = GrapeSwagger::DocMethods::TagNameDescription.build(paths, options)
 
       if options[:tags]
         names = options[:tags].map { |t| t[:name] }

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -4,7 +4,7 @@ module GrapeSwagger
   module DocMethods
     class ParseParams
       class << self
-        def call(param, settings, path, route, definitions)
+        def call(param, settings, path, route, definitions, options)
           method = route.request_method
           additional_documentation = settings.fetch(:documentation, {})
           settings.merge!(additional_documentation)
@@ -19,7 +19,7 @@ module GrapeSwagger
           }
 
           # optional properties
-          document_description(settings)
+          document_description(settings, route, param, options)
           document_type_and_format(settings, data_type)
           document_array_param(value_type, definitions) if value_type[:is_array]
           document_default_value(settings)
@@ -31,9 +31,9 @@ module GrapeSwagger
 
         private
 
-        def document_description(settings)
+        def document_description(settings, route, param, options)
           description = settings[:desc] || settings[:description]
-          @parsed_param[:description] = description if description
+          @parsed_param[:description] = description || Translate.param(route, param, options)
         end
 
         def document_required(settings)

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -33,7 +33,7 @@ module GrapeSwagger
 
         def document_description(settings, route, param, options)
           description = settings[:desc] || settings[:description]
-          @parsed_param[:description] = description || Translate.param(route, param, options)
+          @parsed_param[:description] = Translate.param(route, param, options) || description
         end
 
         def document_required(settings)

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -27,9 +27,7 @@ module GrapeSwagger
 
           path = "#{OptionalObject.build(:base_path, options)}#{path}" if options[:add_base_path]
 
-          i18n_path = Translate.translate path, route.request_method
-
-          [item, path.start_with?('/') ? path : "/#{path}", i18n_path]
+          [item, path.start_with?('/') ? path : "/#{path}"]
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -27,7 +27,9 @@ module GrapeSwagger
 
           path = "#{OptionalObject.build(:base_path, options)}#{path}" if options[:add_base_path]
 
-          [item, path.start_with?('/') ? path : "/#{path}"]
+          i18n_path = Translate.translate path, route.request_method
+
+          [item, path.start_with?('/') ? path : "/#{path}", i18n_path]
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/tag_name_description.rb
+++ b/lib/grape-swagger/doc_methods/tag_name_description.rb
@@ -4,28 +4,19 @@ module GrapeSwagger
   module DocMethods
     class TagNameDescription
       class << self
-        def build(paths)
+        def build(paths, options)
           paths.values.each_with_object([]) do |path, memo|
             tags = path.values.first[:tags]
 
             case tags
             when String
-              memo << build_memo(tags)
+              memo << Translate.tag(options, tags)
             when Array
               path.values.first[:tags].each do |tag|
-                memo << build_memo(tag)
+                memo << Translate.tag(options, tag)
               end
             end
           end.uniq
-        end
-
-        private
-
-        def build_memo(tag)
-          {
-            name: tag,
-            description: "Operations about #{tag.pluralize}"
-          }
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/tag_name_description.rb
+++ b/lib/grape-swagger/doc_methods/tag_name_description.rb
@@ -10,13 +10,22 @@ module GrapeSwagger
 
             case tags
             when String
-              memo << Translate.tag(options, tags)
+              memo << build_memo(tags, options)
             when Array
               path.values.first[:tags].each do |tag|
-                memo << Translate.tag(options, tag)
+                memo << build_memo(tag, options)
               end
             end
           end.uniq
+        end
+
+        private
+
+        def build_memo(tag, options)
+          {
+            name: tag,
+            description: Translate.tag(tag, options) || "Operations about #{tag.pluralize}"
+          }
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -20,6 +20,10 @@ module GrapeSwagger
           translate "#{base(route, options)}.parameters.#{param}"
         end
 
+        def response(route, code, options)
+          translate "#{base(route, options)}.responses.#{code}.message"
+        end
+
         private
 
         def translate(value)

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -25,6 +25,12 @@ module GrapeSwagger
           translate "#{base}.#{clean_path(route)}.detail"
         end
 
+        def param(route, param, options = {})
+          base = prefix(options)
+
+          translate "#{base}.#{clean_path(route)}.parameters.#{param}"
+        end
+
         private
 
         def translate(value)

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -4,37 +4,30 @@ module GrapeSwagger
   module DocMethods
     class Translate
       class << self
-        def tag(options, tag)
-          description = translate "#{prefix(options)}.#{tag.pluralize}.desc"
-
-          {
-            name: tag,
-            description: description
-          }
+        def tag(tag, options)
+          translate "#{prefix(options)}.#{tag.pluralize}.desc"
         end
 
-        def summary(route, options = {})
-          base = prefix(options)
-
-          translate "#{base}.#{clean_path(route)}.desc"
+        def summary(route, options)
+          translate "#{base(route, options)}.desc"
         end
 
-        def description(route, options = {})
-          base = prefix(options)
-
-          translate "#{base}.#{clean_path(route)}.detail"
+        def description(route, options)
+          translate "#{base(route, options)}.detail"
         end
 
-        def param(route, param, options = {})
-          base = prefix(options)
-
-          translate "#{base}.#{clean_path(route)}.parameters.#{param}"
+        def param(route, param, options)
+          translate "#{base(route, options)}.parameters.#{param}"
         end
 
         private
 
         def translate(value)
-          I18n.t(value, default: '')
+          I18n.t(value, default: nil)
+        end
+
+        def base(route, options)
+          "#{prefix(options)}.#{clean_path(route)}"
         end
 
         def prefix(options)

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -49,7 +49,7 @@ module GrapeSwagger
           # always remove base
           path.gsub!(/^(\/(\w+|:\w+)){2}\//, '')
 
-          # add mehtod to path
+          # add method to path
           path.sub!(/^(\w+)\//, '\0{method}/')
           path.sub!(/^(\w+)$/, '\0/{method}')
 

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -4,15 +4,56 @@ module GrapeSwagger
   module DocMethods
     class Translate
       class << self
-        def translate(path, method)
-          path.gsub!(/\{|\}/, '')
-          path.sub!(/^(\/\w+){3}\//, '\0{method}/')
-          path.sub!(/^(\/\w+){3}$/, '\0/{method}')
-          path.sub!('{method}', method.downcase)
-          path.gsub!(/^(\/)/, '')
-          path.gsub!('/', '.')
+        def tag(options, tag)
+          description = translate "#{prefix(options)}.#{tag.pluralize}.desc"
 
-          path
+          {
+            name: tag,
+            description: description
+          }
+        end
+
+        def summary(route, options = {})
+          base = prefix(options)
+
+          translate "#{base}.#{clean_path(route)}.desc"
+        end
+
+        def description(route, options = {})
+          base = prefix(options)
+
+          translate "#{base}.#{clean_path(route)}.detail"
+        end
+
+        private
+
+        def translate(value)
+          I18n.t(value, default: '')
+        end
+
+        def prefix(options)
+          "#{options[:i18n_scope]}.#{options[:version]}"
+        end
+
+        def clean_path(route)
+          path = route.path.dup
+          method = route.request_method.downcase
+
+          # always removing format
+          path.sub!(/\(\.\w+?\)$/, '')
+          path.sub!('(.:format)', '')
+
+          # always remove base
+          path.gsub!(/^(\/(\w+|:\w+)){2}\//, '')
+
+          # add mehtod to path
+          path.sub!(/^(\w+)\//, '\0{method}/')
+          path.sub!(/^(\w+)$/, '\0/{method}')
+
+          # change to dots
+          path.gsub!('/', '.')
+          path.gsub!(/:(\w+)/, '\1')
+          path.sub!('{method}', method)
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/translate.rb
+++ b/lib/grape-swagger/doc_methods/translate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module GrapeSwagger
+  module DocMethods
+    class Translate
+      class << self
+        def translate(path, method)
+          path.gsub!(/\{|\}/, '')
+          path.sub!(/^(\/\w+){3}\//, '\0{method}/')
+          path.sub!(/^(\/\w+){3}$/, '\0/{method}')
+          path.sub!('{method}', method.downcase)
+          path.gsub!(/^(\/)/, '')
+          path.gsub!('/', '.')
+
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -97,7 +97,7 @@ module Grape
       routes.each do |route|
         next if hidden?(route, options)
 
-        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
+        @item, path, i18n_path = GrapeSwagger::DocMethods::PathString.build(route, options)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -97,7 +97,7 @@ module Grape
       routes.each do |route|
         next if hidden?(route, options)
 
-        @item, path, i18n_path = GrapeSwagger::DocMethods::PathString.build(route, options)
+        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)
@@ -114,8 +114,8 @@ module Grape
 
     def method_object(route, options, path)
       method = {}
-      method[:summary]     = summary_object(route)
-      method[:description] = description_object(route)
+      method[:summary]     = summary_object(route, options)
+      method[:description] = description_object(route, options)
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
       method[:parameters]  = params_object(route, path)
@@ -132,19 +132,12 @@ module Grape
       route.options[:security] if route.options.key?(:security)
     end
 
-    def summary_object(route)
-      summary = route.options[:desc] if route.options.key?(:desc)
-      summary = route.description if route.description.present?
-      summary = route.options[:summary] if route.options.key?(:summary)
-
-      summary
+    def summary_object(route, options)
+      GrapeSwagger::DocMethods::Translate.summary(route, options)
     end
 
-    def description_object(route)
-      description = route.description if route.description.present?
-      description = route.options[:detail] if route.options.key?(:detail)
-
-      description
+    def description_object(route, options)
+      GrapeSwagger::DocMethods::Translate.description(route, options)
     end
 
     def produces_object(route, format)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -133,11 +133,18 @@ module Grape
     end
 
     def summary_object(route, options)
-      GrapeSwagger::DocMethods::Translate.summary(route, options)
+      summary = route.options[:desc] if route.options.key?(:desc)
+      summary = route.description if route.description.present?
+      summary = route.options[:summary] if route.options.key?(:summary)
+
+      GrapeSwagger::DocMethods::Translate.summary(route, options) || summary
     end
 
     def description_object(route, options)
-      GrapeSwagger::DocMethods::Translate.description(route, options)
+      description = route.description if route.description.present?
+      description = route.options[:detail] if route.options.key?(:detail)
+
+      GrapeSwagger::DocMethods::Translate.description(route, options) || description
     end
 
     def produces_object(route, format)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -118,7 +118,7 @@ module Grape
       method[:description] = description_object(route, options)
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
-      method[:parameters]  = params_object(route, path)
+      method[:parameters]  = params_object(route, path, options)
       method[:security]    = security_object(route)
       method[:responses]   = response_object(route)
       method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
@@ -164,7 +164,7 @@ module Grape
       mime_types
     end
 
-    def params_object(route, path)
+    def params_object(route, path, options)
       parameters = partition_params(route).map do |param, value|
         value = { required: false }.merge(value) if value.is_a?(Hash)
         _, value = default_type([[param, value]]).first if value == ''
@@ -173,7 +173,7 @@ module Grape
         elsif value[:documentation]
           expose_params(value[:documentation][:type])
         end
-        GrapeSwagger::DocMethods::ParseParams.call(param, value, path, route, @definitions)
+        GrapeSwagger::DocMethods::ParseParams.call(param, value, path, route, @definitions, options)
       end
 
       if GrapeSwagger::DocMethods::MoveParams.can_be_moved?(parameters, route.request_method)


### PR DESCRIPTION
#### [TF-2349](https://lemontech.atlassian.net/browse/TF-2349)

## Requerimiento
Se necesita traducir documentación generada por grape-swagger, además de remover desde los endpoints de tbx código asociado a documentación (`desc`).

## Solución
Modificaciones a la gema grape-swagger que permiten leer un `yml` con traducciones e insertarlas por defecto en la documentación generada

## QA
- Apuntar grape-swagger en el Gemfile de TimeBillingX a esta rama
- Agregar en TBX los locales `api.en.yml` y `api.es.yml`
- Agregar en estos archivos las traducciones para un determinado endpoint. Ej: clients
```yml
---
en:
  api:
    v2:
      clients:
        desc: Una descripción
        get:
          desc: Descripción get
          detail: Detalle get
          parameters:
            q: query bla bla
            active: active bla bla
            holding: holding bla bla
```
- Eliminar los `desc` del endpoint de clients (siguiendo este ejemplo)
- Verificar que las traducciones se aplican en la documentación `tu-local/api/v2/swagger_doc`